### PR TITLE
⚡ Bolt: Optimize VarInt allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-19 - FriendlyByteBuf Allocation Overhead
+**Learning:** `FriendlyByteBuf` is often used as a convenient wrapper around Netty's `ByteBuf` for `read/writeVarInt`. However, instantiating it per-packet in hot paths (like compression/decompression) adds unnecessary allocation overhead. Static utility methods operating directly on `ByteBuf` are preferred for performance-critical code.
+**Action:** Replace `new FriendlyByteBuf(buf)` with `VarIntUtil` static methods in high-throughput network handlers.

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:6.0.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("io.netty:netty-buffer:4.1.118.Final")
+    testImplementation("io.netty:netty-codec:4.1.118.Final")
+    testImplementation("io.netty:netty-handler:4.1.118.Final")
 
     jmh("io.netty:netty-buffer:4.1.118.Final")
     jmh("io.netty:netty-common:4.1.118.Final")
@@ -67,6 +70,10 @@ configurations {
 jmh {
     resultFormat = "JSON"
     zip64 = true
+}
+
+test {
+    useJUnitPlatform()
 }
 
 artifacts {

--- a/common/src/main/java/one/pkg/kfnp/shared/network/compression/MinecraftCompressDecoder.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/compression/MinecraftCompressDecoder.java
@@ -4,8 +4,8 @@ import com.velocitypowered.natives.compression.VelocityCompressor;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
-import net.minecraft.network.FriendlyByteBuf;
 import one.pkg.kfnp.shared.ModConfig;
+import one.pkg.kfnp.shared.network.util.VarIntUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,8 +43,7 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-        FriendlyByteBuf bb = new FriendlyByteBuf(in);
-        int claimedUncompressedSize = bb.readVarInt();
+        int claimedUncompressedSize = VarIntUtil.readVarInt(in);
 
         if (claimedUncompressedSize == 0) {
             int actualUncompressedSize = in.readableBytes();

--- a/common/src/main/java/one/pkg/kfnp/shared/network/compression/MinecraftCompressEncoder.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/compression/MinecraftCompressEncoder.java
@@ -5,8 +5,8 @@ import com.velocitypowered.natives.util.MoreByteBufUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
-import net.minecraft.network.FriendlyByteBuf;
 import one.pkg.kfnp.shared.ModConfig;
+import one.pkg.kfnp.shared.network.util.VarIntUtil;
 
 import static one.pkg.kfnp.shared.network.util.SystemInfo.IS_WINDOWS;
 
@@ -24,14 +24,13 @@ public class MinecraftCompressEncoder extends MessageToByteEncoder<ByteBuf> {
 
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out) throws Exception {
-        FriendlyByteBuf wrappedBuf = new FriendlyByteBuf(out);
         int uncompressed = msg.readableBytes();
         if (uncompressed < threshold) {
             // Under the threshold, there is nothing to do.
-            wrappedBuf.writeVarInt(0);
+            VarIntUtil.writeVarInt(out, 0);
             out.writeBytes(msg);
         } else {
-            wrappedBuf.writeVarInt(uncompressed);
+            VarIntUtil.writeVarInt(out, uncompressed);
 
             VelocityCompressor selectedCompressor = getSelectedCompressor(uncompressed);
             ByteBuf compatibleIn = MoreByteBufUtils.ensureCompatible(ctx.alloc(), selectedCompressor, msg);

--- a/common/src/main/java/one/pkg/kfnp/shared/network/util/VarIntUtil.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/util/VarIntUtil.java
@@ -1,7 +1,7 @@
 package one.pkg.kfnp.shared.network.util;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.util.Mth;
+import io.netty.handler.codec.DecoderException;
 
 /**
  * Maps VarInt byte sizes to a lookup table corresponding to the number of bits in the integer,
@@ -16,13 +16,53 @@ public class VarIntUtil {
 
     static {
         for (int i = 0; i <= 32; ++i) {
-            VARINT_EXACT_BYTE_LENGTHS[i] = Mth.ceil((31d - (i - 1)) / 7d);
+            VARINT_EXACT_BYTE_LENGTHS[i] = (int) Math.ceil((31d - (i - 1)) / 7d);
         }
         VARINT_EXACT_BYTE_LENGTHS[32] = 1; // Special case for 0.
     }
 
     public static int getVarIntLength(int value) {
         return VARINT_EXACT_BYTE_LENGTHS[Integer.numberOfLeadingZeros(value)];
+    }
+
+    public static int readVarInt(ByteBuf buf) {
+        int i = 0;
+        int max = 5;
+        int result = 0;
+        int shift = 0;
+        int b;
+
+        do {
+            if (i >= max) {
+                throw new DecoderException("VarInt is too big");
+            }
+            b = buf.readByte();
+            result |= (b & 127) << shift;
+            shift += 7;
+            i++;
+        } while ((b & 128) != 0);
+        return result;
+    }
+
+    public static void writeVarInt(ByteBuf buf, int value) {
+        if ((value & MASK_7_BITS) == 0) {
+            buf.writeByte(value);
+        } else if ((value & MASK_14_BITS) == 0) {
+            int w = (value & 0x7F | 0x80) << 8 | (value >>> 7);
+            buf.writeShort(w);
+        } else if ((value & MASK_21_BITS) == 0) {
+            int w = (value & 0x7F | 0x80) << 16 | ((value >>> 7) & 0x7F | 0x80) << 8 | (value >>> 14);
+            buf.writeMedium(w);
+        } else if ((value & MASK_28_BITS) == 0) {
+            int w = (value & 0x7F | 0x80) << 24 | (((value >>> 7) & 0x7F | 0x80) << 16)
+                    | ((value >>> 14) & 0x7F | 0x80) << 8 | (value >>> 21);
+            buf.writeInt(w);
+        } else {
+            int w = (value & 0x7F | 0x80) << 24 | ((value >>> 7) & 0x7F | 0x80) << 16
+                    | ((value >>> 14) & 0x7F | 0x80) << 8 | ((value >>> 21) & 0x7F | 0x80);
+            buf.writeInt(w);
+            buf.writeByte(value >>> 28);
+        }
     }
 
     public static void writeVarIntFull0210(ByteBuf buf, int value) {

--- a/common/src/test/java/one/pkg/kfnp/test/VarIntUtilTest.java
+++ b/common/src/test/java/one/pkg/kfnp/test/VarIntUtilTest.java
@@ -1,0 +1,42 @@
+package one.pkg.kfnp.test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import one.pkg.kfnp.shared.network.util.VarIntUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VarIntUtilTest {
+
+    @Test
+    public void testReadWriteVarInt() {
+        testVarInt(0, 1);
+        testVarInt(1, 1);
+        testVarInt(127, 1);
+        testVarInt(128, 2);
+        testVarInt(255, 2);
+        testVarInt(16383, 2); // 14 bits
+        testVarInt(16384, 3);
+        testVarInt(2097151, 3); // 21 bits
+        testVarInt(2097152, 4);
+        testVarInt(268435455, 4); // 28 bits
+        testVarInt(268435456, 5);
+        testVarInt(-1, 5);
+        testVarInt(Integer.MAX_VALUE, 5);
+        testVarInt(Integer.MIN_VALUE, 5);
+    }
+
+    private void testVarInt(int value, int expectedBytes) {
+        ByteBuf buf = Unpooled.buffer();
+        VarIntUtil.writeVarInt(buf, value);
+
+        assertEquals(expectedBytes, buf.readableBytes(), "Byte length mismatch for value: " + value);
+        assertEquals(expectedBytes, VarIntUtil.getVarIntLength(value), "VarIntUtil.getVarIntLength mismatch for value: " + value);
+
+        int read = VarIntUtil.readVarInt(buf);
+        assertEquals(value, read, "Read value mismatch");
+        assertEquals(0, buf.readableBytes(), "Buffer should be empty after read");
+        buf.release();
+    }
+}


### PR DESCRIPTION
💡 What: Replaced FriendlyByteBuf instantiation with static VarIntUtil methods in MinecraftCompressEncoder/Decoder. Added optimized readVarInt/writeVarInt to VarIntUtil.
🎯 Why: Reduces object allocation (FriendlyByteBuf) per packet in hot network paths.
📊 Impact: Reduces allocation rate and GC pressure during high traffic.
🔬 Measurement: Verified with new unit tests covering all VarInt cases.

---
*PR created automatically by Jules for task [10809756476131171299](https://jules.google.com/task/10809756476131171299) started by @404Setup*