### PR TITLE
Fix protocol desynchronization in Varint21FrameDecoderMixin

### DIFF
--- a/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/Varint21FrameDecoderMixin.java
+++ b/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/Varint21FrameDecoderMixin.java
@@ -102,7 +102,29 @@ public class Varint21FrameDecoderMixin {
         if ((tmp = buffer.readByte()) >= 0) {
             return result | tmp << 14;
         }
-        return result | (tmp & 0x7F) << 14;
+        if (!ModConfig.Compatibility.AllowWideVarInt()) {
+            throw VARINT_BIG_CACHED;
+        }
+        result |= (tmp & 0x7F) << 14;
+
+        if (!buffer.isReadable()) {
+            buffer.resetReaderIndex();
+            return 0;
+        }
+        if ((tmp = buffer.readByte()) >= 0) {
+            return result | tmp << 21;
+        }
+        result |= (tmp & 0x7F) << 21;
+
+        if (!buffer.isReadable()) {
+            buffer.resetReaderIndex();
+            return 0;
+        }
+        if ((tmp = buffer.readByte()) >= 0) {
+            return result | tmp << 28;
+        }
+
+        throw VARINT_BIG_CACHED;
     }
 
     /**


### PR DESCRIPTION
Fixed a protocol desynchronization vulnerability in `Varint21FrameDecoderMixin`.

**The Issue:**
The optimized VarInt decoder `readRawVarintSmallBuf` was hardcoded to read at most 3 bytes. If the 3rd byte had the continuation bit set (indicating more bytes follow), the method would return the partial value and advance the reader index by 3. The remaining bytes of the VarInt would then be left in the buffer and interpreted as the start of the next packet (length), causing massive protocol corruption.

**The Fix:**
Updated `readRawVarintSmallBuf` to check the MSB of the 3rd byte.
- If MSB is set:
  - If `AllowWideVarInt` is disabled (default): throw `VARINT_BIG_CACHED` (reject > 3 bytes).
  - If `AllowWideVarInt` is enabled: continue reading the 4th and 5th bytes. If the buffer runs out of data during this process, reset the reader index and return 0 to wait for more data.

**Verification:**
- Confirmed the vulnerability with a reproduction test case (`ReproTest`).
- Verified the fix handles strict mode (throws exception) and wide mode (waits for data or reads full value) correctly.
- Verified existing `VarIntUtilTest` passes.
- Noted pre-existing unrelated failure in `RconClientTest`.

---
*PR created automatically by Jules for task [15953649834704087](https://jules.google.com/task/15953649834704087) started by @404Setup*