### PR TITLE
Fix RconClientTest endianness assertion

### DIFF
--- a/common/src/test/java/one/pkg/kfnp/test/RconClientTest.java
+++ b/common/src/test/java/one/pkg/kfnp/test/RconClientTest.java
@@ -23,7 +23,7 @@ public class RconClientTest {
     public void testRedirectIntFromByteArray() {
         byte[] testBytes = {(byte) 0x12, (byte) 0x34, (byte) 0x56, (byte) 0x78};
         int result = redirectIntFromByteArrayOptimized(testBytes, 0, 4);
-        assertEquals(0x12345678, result);
+        assertEquals(0x78563412, result);
     }
 
     @Test


### PR DESCRIPTION
The test `testRedirectIntFromByteArray` in `RconClientTest.java` was failing with an assertion error because it expected a Big Endian interpretation of the byte array, while the implementation `redirectIntFromByteArrayOptimized` (and the RCON protocol itself) uses Little Endian.

This change updates the expected value to `0x78563412` (2018915346) to match the correct behavior.
Verified by running `./gradlew :common:test --tests "one.pkg.kfnp.test.RconClientTest"`.

---
*PR created automatically by Jules for task [457794216840903034](https://jules.google.com/task/457794216840903034) started by @404Setup*