### PR TITLE
⚡ Optimize RconClient response sending by removing array copies

### DIFF
--- a/common/src/jmh/java/one/pkg/kfnp/jmh/network/RconClientBenchmark.java
+++ b/common/src/jmh/java/one/pkg/kfnp/jmh/network/RconClientBenchmark.java
@@ -1,0 +1,107 @@
+package one.pkg.kfnp.jmh.network;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(1)
+public class RconClientBenchmark {
+
+    private static final int CHUNK_SIZE = 4096;
+    private static final int PACKET_OVERHEAD = 10;
+
+    // Simulate the mixin field
+    private final byte[] chunkBuffer = new byte[CHUNK_SIZE];
+
+    private byte[] messageBytes;
+    private ByteBufAllocator allocator;
+
+    @Param({"100", "4096", "10000", "100000"})
+    public int messageSize;
+
+    @Setup
+    public void setup() {
+        allocator = ByteBufAllocator.DEFAULT;
+        StringBuilder sb = new StringBuilder(messageSize);
+        for (int i = 0; i < messageSize; i++) {
+            sb.append('a');
+        }
+        messageBytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Benchmark
+    public void baseline(Blackhole bh) {
+        int len = messageBytes.length;
+        if (len <= CHUNK_SIZE) {
+            send(0, 0, messageBytes, len, bh);
+        } else {
+            int offset = 0;
+            while (offset < len) {
+                int chunkSize = Math.min(CHUNK_SIZE, len - offset);
+                System.arraycopy(messageBytes, offset, chunkBuffer, 0, chunkSize);
+                send(0, 0, chunkBuffer, chunkSize, bh);
+                offset += chunkSize;
+            }
+        }
+    }
+
+    @Benchmark
+    public void optimized(Blackhole bh) {
+        int len = messageBytes.length;
+        if (len <= CHUNK_SIZE) {
+            sendOptimized(0, 0, messageBytes, 0, len, bh);
+        } else {
+            int offset = 0;
+            while (offset < len) {
+                int chunkSize = Math.min(CHUNK_SIZE, len - offset);
+                sendOptimized(0, 0, messageBytes, offset, chunkSize, bh);
+                offset += chunkSize;
+            }
+        }
+    }
+
+    // Simulate the send method in RconClientMixin
+    private void send(int id, int type, byte[] messageBytes, int length, Blackhole bh) {
+        ByteBuf buf = allocator.buffer(length + PACKET_OVERHEAD + 4);
+        try {
+            buf.writeIntLE(length + PACKET_OVERHEAD);
+            buf.writeIntLE(id);
+            buf.writeIntLE(type);
+            buf.writeBytes(messageBytes, 0, length);
+            buf.writeByte(0);
+            buf.writeByte(0);
+
+            // Consume the buffer content to simulate I/O
+            bh.consume(buf);
+        } finally {
+            buf.release();
+        }
+    }
+
+    // Simulate the optimized send method
+    private void sendOptimized(int id, int type, byte[] messageBytes, int offset, int length, Blackhole bh) {
+        ByteBuf buf = allocator.buffer(length + PACKET_OVERHEAD + 4);
+        try {
+            buf.writeIntLE(length + PACKET_OVERHEAD);
+            buf.writeIntLE(id);
+            buf.writeIntLE(type);
+            buf.writeBytes(messageBytes, offset, length); // Use offset here
+            buf.writeByte(0);
+            buf.writeByte(0);
+
+            // Consume the buffer content to simulate I/O
+            bh.consume(buf);
+        } finally {
+            buf.release();
+        }
+    }
+}

--- a/common/src/main/java/one/pkg/kfnp/mixin/network/experimental/RconClientMixin.java
+++ b/common/src/main/java/one/pkg/kfnp/mixin/network/experimental/RconClientMixin.java
@@ -15,8 +15,6 @@ public class RconClientMixin {
     private static final int CHUNK_SIZE = 4096;
     @Unique
     private static final int PACKET_OVERHEAD = 10;
-    @Unique
-    private final byte[] krypton_fnp$chunkBuffer = new byte[CHUNK_SIZE];
 
     @Shadow
     @Final
@@ -33,17 +31,17 @@ public class RconClientMixin {
     @Overwrite
     private void send(int id, int type, String message) throws IOException {
         byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
-        this.send(id, type, bytes, bytes.length);
+        this.send(id, type, bytes, 0, bytes.length);
     }
 
     @Unique
-    private void send(int id, int type, byte[] messageBytes, int length) throws IOException {
+    private void send(int id, int type, byte[] messageBytes, int offset, int length) throws IOException {
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(length + PACKET_OVERHEAD + 4);
         try {
             buf.writeIntLE(length + PACKET_OVERHEAD);
             buf.writeIntLE(id);
             buf.writeIntLE(type);
-            buf.writeBytes(messageBytes, 0, length);
+            buf.writeBytes(messageBytes, offset, length);
             buf.writeByte(0);
             buf.writeByte(0);
 
@@ -67,13 +65,12 @@ public class RconClientMixin {
         int len = fullBytes.length;
 
         if (len <= CHUNK_SIZE) {
-            this.send(id, 0, fullBytes, len);
+            this.send(id, 0, fullBytes, 0, len);
         } else {
             int offset = 0;
             while (offset < len) {
                 int chunkSize = Math.min(CHUNK_SIZE, len - offset);
-                System.arraycopy(fullBytes, offset, krypton_fnp$chunkBuffer, 0, chunkSize);
-                this.send(id, 0, krypton_fnp$chunkBuffer, chunkSize);
+                this.send(id, 0, fullBytes, offset, chunkSize);
                 offset += chunkSize;
             }
         }


### PR DESCRIPTION
💡 **What:**
- Refactored `RconClientMixin#send` to accept an `offset` parameter, allowing it to write slices of a byte array directly to the output `ByteBuf`.
- Updated `RconClientMixin#sendCmdResponse` to use the enhanced `send` method, eliminating the need for `System.arraycopy` into a temporary `chunkBuffer`.
- Removed the `krypton_fnp$chunkBuffer` field (4KB allocation per client instance).
- Added `RconClientBenchmark.java` to simulate and measure the performance difference.

🎯 **Why:**
- The original implementation copied chunks of large RCON responses into a temporary 4KB buffer before writing them to the Netty buffer. This involved redundant `System.arraycopy` operations and an extra allocation per `RconClient` instance.
- By writing directly from the source array using `ByteBuf.writeBytes(byte[] src, int srcIndex, int length)`, we avoid the intermediate copy, reducing CPU overhead and memory usage.

📊 **Measured Improvement:**
- A JMH benchmark (`RconClientBenchmark`) was added to simulate the scenario.
- Theoretical improvement: Removes one `System.arraycopy` per 4KB chunk and eliminates a 4KB byte array allocation per RconClient instance.
- Note: The benchmark could not be fully executed in the CI environment due to long build times for Minecraft artifacts, but the optimization is algorithmically sound (O(1) vs O(N) copying per chunk). The benchmark code is preserved for future verification.

---
*PR created automatically by Jules for task [12877760628414505716](https://jules.google.com/task/12877760628414505716) started by @404Setup*