### PR TITLE
Refactor compression negotiation and fix mixin compile errors

### DIFF
--- a/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/compression/ConnectionMixin.java
+++ b/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/compression/ConnectionMixin.java
@@ -83,16 +83,6 @@ public class ConnectionMixin implements ConnectionCompressorExtension {
 
                 this.channel.pipeline().fireUserEventTriggered(KryptonPipelineEvent.COMPRESSION_THRESHOLD_UPDATED);
             } else {
-                // If not negotiated yet, wait a tiny bit to allow negotiation to finish.
-                // This is a last resort to handle race conditions in the login flow.
-                if (this.kfnp$compressor == null && !this.channel.eventLoop().inEventLoop()) {
-                     try {
-                         for (int i = 0; i < 50 && this.kfnp$compressor == null; i++) {
-                             Thread.sleep(1);
-                         }
-                     } catch (InterruptedException ignored) {}
-                }
-
                 String requestedCompressor = this.kfnp$compressor;
                 if (requestedCompressor == null) {
                     requestedCompressor = "deflate";

--- a/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/compression/ServerLoginPacketListenerImplMixin.java
+++ b/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/compression/ServerLoginPacketListenerImplMixin.java
@@ -38,8 +38,6 @@ public class ServerLoginPacketListenerImplMixin {
     @Unique
     private int krypton_fnp$delayedThreshold = -1;
     @Unique
-    private int krypton_fnp$waitTicks = 0;
-    @Unique
     private boolean krypton_fnp$waitingForNegotiation = false;
 
     @Inject(method = "handleHello", at = @At("RETURN"))
@@ -72,27 +70,11 @@ public class ServerLoginPacketListenerImplMixin {
         this.connection.send(new ClientboundCustomQueryPacket(KRYPTON_COMPRESSION_QUERY_ID, payload));
     }
 
-    @Inject(method = "setCompressionThreshold", at = @At("HEAD"), cancellable = true)
-    public void onSetCompressionThreshold(int threshold, CallbackInfo ci) {
+    @Inject(method = "lambda$verifyLoginAndFinishConnectionSetup$0", at = @At("HEAD"), cancellable = true)
+    private void onSetCompressionThreshold(CallbackInfo ci) {
         if (krypton_fnp$waitingForNegotiation && ((ConnectionCompressorExtension) this.connection).kfnp$getCompressor() == null) {
-            krypton_fnp$delayedThreshold = threshold;
+            krypton_fnp$delayedThreshold = this.server.getCompressionThreshold();
             ci.cancel();
-        }
-    }
-
-    @Inject(method = "tick", at = @At("HEAD"))
-    public void onTick(CallbackInfo ci) {
-        if (krypton_fnp$waitingForNegotiation) {
-            if (((ConnectionCompressorExtension) this.connection).kfnp$getCompressor() != null || krypton_fnp$waitTicks >= 40) {
-                krypton_fnp$waitingForNegotiation = false;
-                if (krypton_fnp$delayedThreshold != -1) {
-                    int t = krypton_fnp$delayedThreshold;
-                    krypton_fnp$delayedThreshold = -1;
-                    this.connection.setupCompression(t, true);
-                }
-            } else {
-                krypton_fnp$waitTicks++;
-            }
         }
     }
 
@@ -131,6 +113,12 @@ public class ServerLoginPacketListenerImplMixin {
             }
 
             krypton_fnp$waitingForNegotiation = false;
+            if (krypton_fnp$delayedThreshold != -1) {
+                int t = krypton_fnp$delayedThreshold;
+                krypton_fnp$delayedThreshold = -1;
+                this.connection.setupCompression(t, true);
+            }
+
             ci.cancel();
         }
     }


### PR DESCRIPTION
- Refactored `ServerLoginPacketListenerImplMixin` to trigger compression immediately upon receiving the negotiation query response rather than polling via `@Inject(method = "tick")`.
- Refactored `ConnectionMixin` to remove the `Thread.sleep` block used as a hacky fallback for negotiation race conditions.
- Fixed a compile error in `ServerLoginPacketListenerImplMixin` caused by the missing method `setCompressionThreshold` by appropriately targeting the `lambda$verifyLoginAndFinishConnectionSetup$0` lambda that now handles compression setup in Minecraft 1.21.11.

---
*PR created automatically by Jules for task [14982840772093343993](https://jules.google.com/task/14982840772093343993) started by @404Setup*