### PR TITLE
feat: Add Happy Eyeballs (RFC 8305) support for fast dual-stack fallback

### DIFF
--- a/common/src/main/java/one/pkg/kfnp/mixin/accessor/ConnectionAccessor.java
+++ b/common/src/main/java/one/pkg/kfnp/mixin/accessor/ConnectionAccessor.java
@@ -1,0 +1,12 @@
+package one.pkg.kfnp.mixin.accessor;
+
+import net.minecraft.network.BandwidthDebugMonitor;
+import net.minecraft.network.Connection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Connection.class)
+public interface ConnectionAccessor {
+    @Accessor("bandwidthDebugMonitor")
+    BandwidthDebugMonitor getBandwidthDebugMonitor();
+}

--- a/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/ClientConnectionMixin.java
+++ b/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/ClientConnectionMixin.java
@@ -1,0 +1,26 @@
+package one.pkg.kfnp.mixin.network.pipeline;
+
+import net.minecraft.network.Connection;
+import net.minecraft.server.network.EventLoopGroupHolder;
+import net.minecraft.util.debugchart.LocalSampleLogger;
+import one.pkg.kfnp.shared.ModConfig;
+import one.pkg.kfnp.shared.network.he.HappyEyeballsConnect;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.net.InetSocketAddress;
+
+@Mixin(Connection.class)
+public class ClientConnectionMixin {
+    @Inject(method = "connectToServer", at = @At("HEAD"), cancellable = true)
+    private static void happyEyeballsConnectToServer(InetSocketAddress address, EventLoopGroupHolder eventLoopGroupHolder, LocalSampleLogger bandwidthLogger, CallbackInfoReturnable<Connection> cir) {
+        if (ModConfig.Netty.isHappyEyeballs() && !address.isUnresolved() && address.getHostString() != null) {
+            Connection connection = HappyEyeballsConnect.connectToServer(address, eventLoopGroupHolder, bandwidthLogger);
+            if (connection != null) {
+                cir.setReturnValue(connection);
+            }
+        }
+    }
+}

--- a/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/ClientConnectionMixin.java
+++ b/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/ClientConnectionMixin.java
@@ -12,6 +12,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.net.InetSocketAddress;
 
+// TODO: Prevent log crash pollution, although this function will not affect the connection
+// TODO: I didn't implement Ping compatibility
 @Mixin(Connection.class)
 public abstract class ClientConnectionMixin {
     @Inject(method = "connectToServer", at = @At("HEAD"), cancellable = true)

--- a/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/ClientConnectionMixin.java
+++ b/common/src/main/java/one/pkg/kfnp/mixin/network/pipeline/ClientConnectionMixin.java
@@ -4,7 +4,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.server.network.EventLoopGroupHolder;
 import net.minecraft.util.debugchart.LocalSampleLogger;
 import one.pkg.kfnp.shared.ModConfig;
-import one.pkg.kfnp.shared.network.he.HappyEyeballsConnect;
+import one.pkg.kfnp.shared.network.he.HEConnect;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -13,11 +13,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.net.InetSocketAddress;
 
 @Mixin(Connection.class)
-public class ClientConnectionMixin {
+public abstract class ClientConnectionMixin {
     @Inject(method = "connectToServer", at = @At("HEAD"), cancellable = true)
     private static void happyEyeballsConnectToServer(InetSocketAddress address, EventLoopGroupHolder eventLoopGroupHolder, LocalSampleLogger bandwidthLogger, CallbackInfoReturnable<Connection> cir) {
         if (ModConfig.Netty.isHappyEyeballs() && !address.isUnresolved() && address.getHostString() != null) {
-            Connection connection = HappyEyeballsConnect.connectToServer(address, eventLoopGroupHolder, bandwidthLogger);
+            Connection connection = HEConnect.connectToServer(address, eventLoopGroupHolder, bandwidthLogger);
             if (connection != null) {
                 cir.setReturnValue(connection);
             }

--- a/common/src/main/java/one/pkg/kfnp/shared/ModConfig.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/ModConfig.java
@@ -41,6 +41,8 @@ public class ModConfig {
     private static boolean var14 = false;
     @ConfigTarget(group = "netty", value = "allocatorMaxOrder", comment = "Change Netty's default 16MiB memory allocation to 4MiB, as Minecraft has a 2MiB packet size limit.")
     private static int var15 = 9;
+    @ConfigTarget(group = "netty", value = "happyEyeballs", comment = "Enable Happy Eyeballs (RFC 8305) for client connections to race IPv6 and IPv4.")
+    private static boolean var16 = false;
 
     static {
         config = new SewliaConfig(ConfigMeta.of(
@@ -147,6 +149,10 @@ public class ModConfig {
     public static class Netty {
         public static int getAllocatorMaxOrder() {
             return var15;
+        }
+
+        public static boolean isHappyEyeballs() {
+            return var16;
         }
     }
 }

--- a/common/src/main/java/one/pkg/kfnp/shared/ModMixinBootstrap.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/ModMixinBootstrap.java
@@ -136,6 +136,7 @@ public class ModMixinBootstrap implements IMixinConfigPlugin {
         BestVarLong("one.pkg.kfnp.mixin.network.microopt.VarLongMixin", ModConfig.Mixin::isBestVarLong),
         ClientEncrypt("one.pkg.kfnp.mixin.network.pipeline.encryption.ClientLoginMixin", ModConfig.Mixin::isClientEncrypt),
         RconClient("one.pkg.kfnp.mixin.network.experimental.RconClientMixin", ModConfig.Mixin::isRconClient),
+        HappyEyeballs("one.pkg.kfnp.mixin.network.pipeline.ClientConnectionMixin", ModConfig.Netty::isHappyEyeballs),
         ;
 
         public final String CLASS;

--- a/common/src/main/java/one/pkg/kfnp/shared/ModMixinBootstrap.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/ModMixinBootstrap.java
@@ -136,7 +136,7 @@ public class ModMixinBootstrap implements IMixinConfigPlugin {
         BestVarLong("one.pkg.kfnp.mixin.network.microopt.VarLongMixin", ModConfig.Mixin::isBestVarLong),
         ClientEncrypt("one.pkg.kfnp.mixin.network.pipeline.encryption.ClientLoginMixin", ModConfig.Mixin::isClientEncrypt),
         RconClient("one.pkg.kfnp.mixin.network.experimental.RconClientMixin", ModConfig.Mixin::isRconClient),
-        HappyEyeballs("one.pkg.kfnp.mixin.network.pipeline.ClientConnectionMixin", ModConfig.Netty::isHappyEyeballs),
+        HappyEyeballs("one.pkg.kfnp.mixin.network.pipeline.ClientConnectionMixin", () -> ModConfig.Netty.isHappyEyeballs() && Loader.INSTANCE.isClient()),
         ;
 
         public final String CLASS;

--- a/common/src/main/java/one/pkg/kfnp/shared/network/compression/MinecraftCompressDecoder.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/compression/MinecraftCompressDecoder.java
@@ -169,7 +169,7 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     @Override
-    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    public void handlerRemoved(ChannelHandlerContext ctx) {
         compressor.close();
         if (jCompressor != null) jCompressor.close();
     }

--- a/common/src/main/java/one/pkg/kfnp/shared/network/he/HEConnect.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/he/HEConnect.java
@@ -2,20 +2,17 @@ package one.pkg.kfnp.shared.network.he;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.ScheduledFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.net.Inet4Address;
-import java.net.Inet6Address;
-import java.net.InetAddress;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.server.network.EventLoopGroupHolder;
 import net.minecraft.util.debugchart.LocalSampleLogger;
+import one.pkg.kfnp.mixin.accessor.ConnectionAccessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
+import java.net.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -23,19 +20,24 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class HappyEyeballsConnect {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HappyEyeballsConnect.class);
+public class HEConnect {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HEConnect.class);
     private static final long CONNECTION_ATTEMPT_DELAY_MS = 250;
 
     public static Connection connectToServer(InetSocketAddress address, EventLoopGroupHolder eventLoopGroupHolder, LocalSampleLogger bandwidthLogger) {
         String host = address.getHostString();
+
+        if (address.getAddress() != null && host.equals(address.getAddress().getHostAddress())) {
+            return null;
+        }
+
         int port = address.getPort();
 
         InetAddress[] addresses;
         try {
             addresses = InetAddress.getAllByName(host);
         } catch (UnknownHostException e) {
-            return null; // Let the original method handle the error
+            return null;
         }
 
         List<InetAddress> ipv6Addresses = new ArrayList<>();
@@ -50,13 +52,14 @@ public class HappyEyeballsConnect {
         }
 
         if (ipv6Addresses.isEmpty() || ipv4Addresses.isEmpty()) {
-            return null; // Fallback to Minecraft's standard connection logic if not dual-stack
+            return null;
         }
 
-        InetAddress ipv6 = ipv6Addresses.get(0);
-        InetAddress ipv4 = ipv4Addresses.get(0);
+        InetAddress ipv6 = ipv6Addresses.getFirst();
+        InetAddress ipv4 = ipv4Addresses.getFirst();
 
-        LOGGER.debug("HappyEyeballs: Racing IPv6 {} and IPv4 {} for {}", ipv6, ipv4, host);
+        LOGGER.debug("HE: Racing IPv6 {} and IPv4 {} for {}", ipv6.getHostAddress(), ipv4.getHostAddress(), host);
+
 
         Connection connection = new Connection(PacketFlow.CLIENTBOUND);
         if (bandwidthLogger != null) {
@@ -69,7 +72,7 @@ public class HappyEyeballsConnect {
         Bootstrap baseBootstrap = new Bootstrap()
                 .group(group)
                 .channel(channelClass)
-                .handler(new ChannelInitializer<Channel>() {
+                .handler(new ChannelInitializer<>() {
                     @Override
                     protected void initChannel(Channel ch) {
                         // Base placeholder
@@ -82,18 +85,30 @@ public class HappyEyeballsConnect {
         Bootstrap ipv6Bootstrap = baseBootstrap.clone();
         Bootstrap ipv4Bootstrap = baseBootstrap.clone();
 
-        HEConnectHandler ipv6Handler = new HEConnectHandler(winnerChosen, winnerFuture, connection);
-        ipv6Bootstrap.handler(new ChannelInitializer<Channel>() {
+        HEConnectHandler ipv6Handler = new HEConnectHandler(winnerChosen, winnerFuture);
+        ipv6Bootstrap.handler(new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) {
+                try {
+                    ch.config().setOption(ChannelOption.TCP_NODELAY, true);
+                } catch (ChannelException var3) {
+                }
+
+                ch.pipeline().addLast("timeout", new ReadTimeoutHandler(30));
                 ch.pipeline().addLast("he_handler", ipv6Handler);
             }
         });
 
-        HEConnectHandler ipv4Handler = new HEConnectHandler(winnerChosen, winnerFuture, connection);
-        ipv4Bootstrap.handler(new ChannelInitializer<Channel>() {
+        HEConnectHandler ipv4Handler = new HEConnectHandler(winnerChosen, winnerFuture);
+        ipv4Bootstrap.handler(new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) {
+                try {
+                    ch.config().setOption(ChannelOption.TCP_NODELAY, true);
+                } catch (ChannelException var3) {
+                }
+
+                ch.pipeline().addLast("timeout", new ReadTimeoutHandler(30));
                 ch.pipeline().addLast("he_handler", ipv4Handler);
             }
         });
@@ -103,7 +118,7 @@ public class HappyEyeballsConnect {
 
         ScheduledFuture<?> timer = eventLoop.schedule(() -> {
             if (!winnerChosen.get()) {
-                LOGGER.debug("HappyEyeballs: IPv6 connection delayed, launching IPv4 fallback for {}", ipv4);
+                LOGGER.debug("HE: IPv6 connection delayed, launching IPv4 fallback for {}", ipv4.getHostAddress());
                 ChannelFuture ipv4Future = ipv4Bootstrap.connect(ipv4, port);
                 ipv6Handler.setOtherFuture(ipv4Future);
                 ipv4Handler.setOtherFuture(ipv6Future);
@@ -123,7 +138,7 @@ public class HappyEyeballsConnect {
         ipv6Future.addListener(future -> {
             if (!future.isSuccess() && !winnerChosen.get()) {
                 if (!timer.isDone() && timer.cancel(false)) {
-                    LOGGER.debug("HappyEyeballs: IPv6 connection failed, launching IPv4 fallback for {}", ipv4);
+                    LOGGER.debug("HE: IPv6 connection failed, launching IPv4 fallback for {}", ipv4.getHostAddress());
                     ChannelFuture ipv4Future = ipv4Bootstrap.connect(ipv4, port);
                     ipv6Handler.setOtherFuture(ipv4Future);
                     ipv4Handler.setOtherFuture(ipv6Future);
@@ -139,7 +154,14 @@ public class HappyEyeballsConnect {
 
         try {
             Channel winningChannel = winnerFuture.get();
-            Connection.configureSerialization(winningChannel.pipeline(), PacketFlow.CLIENTBOUND, false, null);
+
+            Connection.configureSerialization(
+                    winningChannel.pipeline(),
+                    PacketFlow.CLIENTBOUND,
+                    false,
+                    ((ConnectionAccessor) connection).getBandwidthDebugMonitor()
+            );
+
             connection.configurePacketHandler(winningChannel.pipeline());
             return connection;
         } catch (ExecutionException e) {

--- a/common/src/main/java/one/pkg/kfnp/shared/network/he/HEConnectHandler.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/he/HEConnectHandler.java
@@ -1,11 +1,14 @@
 package one.pkg.kfnp.shared.network.he;
 
-import io.netty.channel.*;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.concurrent.ScheduledFuture;
-import net.minecraft.network.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -14,14 +17,12 @@ public class HEConnectHandler extends ChannelInboundHandlerAdapter {
 
     private final AtomicBoolean winnerChosen;
     private final CompletableFuture<Channel> winnerFuture;
-    private final Connection connection;
     private ChannelFuture otherFuture;
     private ScheduledFuture<?> timer;
 
-    public HEConnectHandler(AtomicBoolean winnerChosen, CompletableFuture<Channel> winnerFuture, Connection connection) {
+    public HEConnectHandler(AtomicBoolean winnerChosen, CompletableFuture<Channel> winnerFuture) {
         this.winnerChosen = winnerChosen;
         this.winnerFuture = winnerFuture;
-        this.connection = connection;
     }
 
     public void setOtherFuture(ChannelFuture otherFuture) {
@@ -33,9 +34,13 @@ public class HEConnectHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+    public void channelActive(ChannelHandlerContext ctx) {
         if (winnerChosen.compareAndSet(false, true)) {
-            LOGGER.debug("HappyEyeballs: Connection succeeded on {}", ctx.channel().remoteAddress());
+            if (ctx.channel().remoteAddress() instanceof InetSocketAddress inetAddr) {
+                LOGGER.debug("HE: Connection succeeded on {}:{}", inetAddr.getHostString(), inetAddr.getPort());
+            } else {
+                LOGGER.debug("HE: Connection succeeded on {}", ctx.channel().remoteAddress());
+            }
             if (timer != null) timer.cancel(false);
             if (otherFuture != null && otherFuture.channel() != null) {
                 otherFuture.channel().close();
@@ -61,7 +66,7 @@ public class HEConnectHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         if (!winnerChosen.get()) {
             if (otherFuture != null && otherFuture.isDone() && !otherFuture.isSuccess()) {
                 winnerFuture.completeExceptionally(cause);

--- a/common/src/main/java/one/pkg/kfnp/shared/network/he/HEConnectHandler.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/he/HEConnectHandler.java
@@ -1,0 +1,72 @@
+package one.pkg.kfnp.shared.network.he;
+
+import io.netty.channel.*;
+import io.netty.util.concurrent.ScheduledFuture;
+import net.minecraft.network.Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class HEConnectHandler extends ChannelInboundHandlerAdapter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HEConnectHandler.class);
+
+    private final AtomicBoolean winnerChosen;
+    private final CompletableFuture<Channel> winnerFuture;
+    private final Connection connection;
+    private ChannelFuture otherFuture;
+    private ScheduledFuture<?> timer;
+
+    public HEConnectHandler(AtomicBoolean winnerChosen, CompletableFuture<Channel> winnerFuture, Connection connection) {
+        this.winnerChosen = winnerChosen;
+        this.winnerFuture = winnerFuture;
+        this.connection = connection;
+    }
+
+    public void setOtherFuture(ChannelFuture otherFuture) {
+        this.otherFuture = otherFuture;
+    }
+
+    public void setTimer(ScheduledFuture<?> timer) {
+        this.timer = timer;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        if (winnerChosen.compareAndSet(false, true)) {
+            LOGGER.debug("HappyEyeballs: Connection succeeded on {}", ctx.channel().remoteAddress());
+            if (timer != null) timer.cancel(false);
+            if (otherFuture != null && otherFuture.channel() != null) {
+                otherFuture.channel().close();
+            }
+
+            ctx.pipeline().remove(this);
+            winnerFuture.complete(ctx.channel());
+
+            ctx.fireChannelActive();
+        } else {
+            ctx.channel().close();
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (!winnerChosen.get()) {
+            if (otherFuture != null && otherFuture.isDone() && !otherFuture.isSuccess()) {
+                winnerFuture.completeExceptionally(new RuntimeException("Both IPv6 and IPv4 connections failed."));
+            }
+        }
+        super.channelInactive(ctx);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        if (!winnerChosen.get()) {
+            if (otherFuture != null && otherFuture.isDone() && !otherFuture.isSuccess()) {
+                winnerFuture.completeExceptionally(cause);
+            }
+        }
+        ctx.channel().close();
+    }
+}

--- a/common/src/main/java/one/pkg/kfnp/shared/network/he/HappyEyeballsConnect.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/he/HappyEyeballsConnect.java
@@ -1,0 +1,154 @@
+package one.pkg.kfnp.shared.network.he;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.*;
+import io.netty.util.concurrent.ScheduledFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.PacketFlow;
+import net.minecraft.server.network.EventLoopGroupHolder;
+import net.minecraft.util.debugchart.LocalSampleLogger;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class HappyEyeballsConnect {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HappyEyeballsConnect.class);
+    private static final long CONNECTION_ATTEMPT_DELAY_MS = 250;
+
+    public static Connection connectToServer(InetSocketAddress address, EventLoopGroupHolder eventLoopGroupHolder, LocalSampleLogger bandwidthLogger) {
+        String host = address.getHostString();
+        int port = address.getPort();
+
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            return null; // Let the original method handle the error
+        }
+
+        List<InetAddress> ipv6Addresses = new ArrayList<>();
+        List<InetAddress> ipv4Addresses = new ArrayList<>();
+
+        for (InetAddress addr : addresses) {
+            if (addr instanceof Inet6Address) {
+                ipv6Addresses.add(addr);
+            } else if (addr instanceof Inet4Address) {
+                ipv4Addresses.add(addr);
+            }
+        }
+
+        if (ipv6Addresses.isEmpty() || ipv4Addresses.isEmpty()) {
+            return null; // Fallback to Minecraft's standard connection logic if not dual-stack
+        }
+
+        InetAddress ipv6 = ipv6Addresses.get(0);
+        InetAddress ipv4 = ipv4Addresses.get(0);
+
+        LOGGER.debug("HappyEyeballs: Racing IPv6 {} and IPv4 {} for {}", ipv6, ipv4, host);
+
+        Connection connection = new Connection(PacketFlow.CLIENTBOUND);
+        if (bandwidthLogger != null) {
+            connection.setBandwidthLogger(bandwidthLogger);
+        }
+
+        EventLoopGroup group = eventLoopGroupHolder.eventLoopGroup();
+        Class<? extends Channel> channelClass = eventLoopGroupHolder.channelCls();
+
+        Bootstrap baseBootstrap = new Bootstrap()
+                .group(group)
+                .channel(channelClass)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                        // Base placeholder
+                    }
+                });
+
+        AtomicBoolean winnerChosen = new AtomicBoolean(false);
+        CompletableFuture<Channel> winnerFuture = new CompletableFuture<>();
+
+        Bootstrap ipv6Bootstrap = baseBootstrap.clone();
+        Bootstrap ipv4Bootstrap = baseBootstrap.clone();
+
+        HEConnectHandler ipv6Handler = new HEConnectHandler(winnerChosen, winnerFuture, connection);
+        ipv6Bootstrap.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) {
+                ch.pipeline().addLast("he_handler", ipv6Handler);
+            }
+        });
+
+        HEConnectHandler ipv4Handler = new HEConnectHandler(winnerChosen, winnerFuture, connection);
+        ipv4Bootstrap.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) {
+                ch.pipeline().addLast("he_handler", ipv4Handler);
+            }
+        });
+
+        ChannelFuture ipv6Future = ipv6Bootstrap.connect(ipv6, port);
+        EventLoop eventLoop = ipv6Future.channel().eventLoop();
+
+        ScheduledFuture<?> timer = eventLoop.schedule(() -> {
+            if (!winnerChosen.get()) {
+                LOGGER.debug("HappyEyeballs: IPv6 connection delayed, launching IPv4 fallback for {}", ipv4);
+                ChannelFuture ipv4Future = ipv4Bootstrap.connect(ipv4, port);
+                ipv6Handler.setOtherFuture(ipv4Future);
+                ipv4Handler.setOtherFuture(ipv6Future);
+
+                ipv4Future.addListener(future -> {
+                    if (!future.isSuccess() && !winnerChosen.get()) {
+                        if (ipv6Future.isDone() && !ipv6Future.isSuccess()) {
+                            winnerFuture.completeExceptionally(future.cause());
+                        }
+                    }
+                });
+            }
+        }, CONNECTION_ATTEMPT_DELAY_MS, TimeUnit.MILLISECONDS);
+
+        ipv6Handler.setTimer(timer);
+
+        ipv6Future.addListener(future -> {
+            if (!future.isSuccess() && !winnerChosen.get()) {
+                if (!timer.isDone() && timer.cancel(false)) {
+                    LOGGER.debug("HappyEyeballs: IPv6 connection failed, launching IPv4 fallback for {}", ipv4);
+                    ChannelFuture ipv4Future = ipv4Bootstrap.connect(ipv4, port);
+                    ipv6Handler.setOtherFuture(ipv4Future);
+                    ipv4Handler.setOtherFuture(ipv6Future);
+
+                    ipv4Future.addListener(f4 -> {
+                        if (!f4.isSuccess() && !winnerChosen.get()) {
+                            winnerFuture.completeExceptionally(f4.cause());
+                        }
+                    });
+                }
+            }
+        });
+
+        try {
+            Channel winningChannel = winnerFuture.get();
+            Connection.configureSerialization(winningChannel.pipeline(), PacketFlow.CLIENTBOUND, false, null);
+            connection.configurePacketHandler(winningChannel.pipeline());
+            return connection;
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+            throw new RuntimeException(cause);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/common/src/main/java/one/pkg/kfnp/shared/network/pipeline/MinecraftCipherDecoder.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/pipeline/MinecraftCipherDecoder.java
@@ -18,7 +18,7 @@ public class MinecraftCipherDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         ByteBuf compatible = MoreByteBufUtils.ensureCompatible(ctx.alloc(), cipher, in).slice();
         try {
             cipher.process(compatible);
@@ -30,7 +30,7 @@ public class MinecraftCipherDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     @Override
-    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    public void handlerRemoved(ChannelHandlerContext ctx) {
         cipher.close();
     }
 }

--- a/common/src/main/java/one/pkg/kfnp/shared/network/pipeline/MinecraftCipherEncoder.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/pipeline/MinecraftCipherEncoder.java
@@ -18,7 +18,7 @@ public class MinecraftCipherEncoder extends MessageToMessageEncoder<ByteBuf> {
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
+    protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) {
         ByteBuf compatible = MoreByteBufUtils.ensureCompatible(ctx.alloc(), cipher, msg);
         try {
             cipher.process(compatible);
@@ -30,7 +30,7 @@ public class MinecraftCipherEncoder extends MessageToMessageEncoder<ByteBuf> {
     }
 
     @Override
-    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    public void handlerRemoved(ChannelHandlerContext ctx) {
         cipher.close();
     }
 }

--- a/common/src/main/java/one/pkg/kfnp/shared/network/pipeline/MinecraftVarintPrepender.java
+++ b/common/src/main/java/one/pkg/kfnp/shared/network/pipeline/MinecraftVarintPrepender.java
@@ -16,7 +16,7 @@ public class MinecraftVarintPrepender extends MessageToMessageEncoder<ByteBuf> {
     static final boolean IS_JAVA_CIPHER = Natives.cipher.get() == JavaVelocityCipher.FACTORY;
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
+    protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) {
         final int length = msg.readableBytes();
         final int varintLength = VarInt.getByteSize(length);
 

--- a/common/src/main/resources/krypton_fnp.mixins.json
+++ b/common/src/main/resources/krypton_fnp.mixins.json
@@ -5,10 +5,11 @@
   "plugin": "one.pkg.kfnp.shared.ModMixinBootstrap",
   "compatibilityLevel": "JAVA_21",
   "client": [
-    "network.pipeline.encryption.ClientLoginMixin",
-    "network.pipeline.ClientConnectionMixin"
+    "network.pipeline.ClientConnectionMixin",
+    "network.pipeline.encryption.ClientLoginMixin"
   ],
   "mixins": [
+    "accessor.ConnectionAccessor",
     "network.experimental.RconClientMixin",
     "network.microopt.ServerEntityMixin",
     "network.microopt.Utf8StringMixin",

--- a/common/src/main/resources/krypton_fnp.mixins.json
+++ b/common/src/main/resources/krypton_fnp.mixins.json
@@ -5,7 +5,8 @@
   "plugin": "one.pkg.kfnp.shared.ModMixinBootstrap",
   "compatibilityLevel": "JAVA_21",
   "client": [
-    "network.pipeline.encryption.ClientLoginMixin"
+    "network.pipeline.encryption.ClientLoginMixin",
+    "network.pipeline.ClientConnectionMixin"
   ],
   "mixins": [
     "network.experimental.RconClientMixin",


### PR DESCRIPTION
This PR introduces "Happy Eyeballs" (Fast Fallback, RFC 8305) support to the Minecraft client connection sequence. 

When a server hostname resolves to both IPv4 and IPv6 addresses (dual-stack), standard Minecraft only connects to the first returned address, leading to long timeouts or complete connection failures if that specific route is broken.

This patch intercepts the connection logic *before* reverse-DNS resolution, looks up both A and AAAA records, and races the TCP connection attempts using Netty. IPv6 is given a 250ms head start. The fastest successful connection is handed over to the Minecraft network pipeline, and the slower connection is closed. This significantly improves responsiveness and reliability for users on imperfect dual-stack networks.

The feature is disabled by default to prevent triggering aggressive anti-spam "Connection Throttled" plugins on legacy servers. It can be enabled via the `happyEyeballs` config option.