### PR TITLE
fix: prevent potential thread/memory exhaustion in packet decoding

### DIFF
--- a/common/src/main/java/one/pkg/kreno/mixin/network/pipeline/Varint21FrameDecoderMixin.java
+++ b/common/src/main/java/one/pkg/kreno/mixin/network/pipeline/Varint21FrameDecoderMixin.java
@@ -10,8 +10,10 @@ import one.pkg.kreno.shared.network.util.VarIntUtil;
 import org.spongepowered.asm.mixin.*;
 
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import static io.netty.util.ByteProcessor.FIND_NON_NUL;
 import static one.pkg.kreno.shared.network.util.WellKnownExceptions.BAD_LENGTH_CACHED;
@@ -24,7 +26,13 @@ import static one.pkg.kreno.shared.network.util.WellKnownExceptions.VARINT_BIG_C
 @Mixin(Varint21FrameDecoder.class)
 public class Varint21FrameDecoderMixin {
     @Unique
-    private final ExecutorService kreno$executor = Executors.newSingleThreadExecutor(Thread.ofVirtual().factory());
+    private final ExecutorService kreno$executor = new ThreadPoolExecutor(
+            1, 1,
+            0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1024),
+            Thread.ofVirtual().factory(),
+            new ThreadPoolExecutor.DiscardPolicy()
+    );
     @Final
     @Shadow
     private BandwidthDebugMonitor monitor;


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed a potential Denial of Service (DoS) vulnerability via memory/thread exhaustion in `Varint21FrameDecoderMixin.java`. The `kreno$executor` was using `Executors.newSingleThreadExecutor()`, which is backed by an unbounded queue.

⚠️ **Risk:** The potential impact if left unfixed
A malicious actor could send a rapid stream of small or malformed packets (e.g., a "nullping" flood) to the server. Because the packet decoding thread operates quickly while offloading monitoring data to the unbounded queue, the queue would grow uncontrollably until the server exhausted its heap memory (OOM), crashing the Minecraft server entirely.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the `Executors.newSingleThreadExecutor()` with a manually configured `ThreadPoolExecutor` backed by a fixed-size `ArrayBlockingQueue` (capacity of 1024). Additionally, configured the executor with a `DiscardPolicy`. Under normal load, behavior remains identical. Under severe attack, excess background monitoring logs are safely dropped, ensuring the server remains stable.

---
*PR created automatically by Jules for task [1513082645166451552](https://jules.google.com/task/1513082645166451552) started by @404Setup*