### PR TITLE
Prevent untrusted search path vulnerability in native library loading

### DIFF
--- a/common/src/main/java/one/pkg/kreno/shared/misc/NativeDependencyChecker.java
+++ b/common/src/main/java/one/pkg/kreno/shared/misc/NativeDependencyChecker.java
@@ -44,12 +44,11 @@ public class NativeDependencyChecker {
 
         if (IS_WINDOWS) {
             String systemDrive = System.getenv("SystemDrive");
-            if (systemDrive == null || systemDrive.isEmpty()) {
+            if (systemDrive == null || !systemDrive.matches("^[a-zA-Z]:$")) {
                 systemDrive = "C:";
             }
 
             String[] possiblePaths = {
-                    System.getenv("OPENSSL_DIR"),
                     systemDrive + "\\Program Files\\OpenSSL-Win64\\bin",
                     systemDrive + "\\Program Files\\OpenSSL\\bin",
                     systemDrive + "\\OpenSSL-Win64\\bin",


### PR DESCRIPTION
🎯 **What:** Fixed an untrusted search path vulnerability in `NativeDependencyChecker.java` where native OpenSSL `.dll` files could be loaded from an attacker-controlled directory via the `OPENSSL_DIR` and `SystemDrive` environment variables.

⚠️ **Risk:** If left unfixed, an attacker who could manipulate these environment variables could trick the application into loading a malicious `.dll` file instead of the legitimate OpenSSL library, leading to arbitrary code execution (DLL Hijacking). Additionally, without validating the `SystemDrive` variable, the path could be set to an untrusted UNC share (e.g. `\\malicious\share`), compromising the application's integrity and security.

🛡️ **Solution:** 
- Completely removed the inclusion of `System.getenv("OPENSSL_DIR")` from the `possiblePaths` array to prevent loading from arbitrary locations.
- Added strict regular expression validation (`^[a-zA-Z]:$`) to the `systemDrive` environment variable check. If `SystemDrive` does not strictly map to a valid Windows drive letter, it safely falls back to `"C:"`, mitigating UNC path injection risks.

---
*PR created automatically by Jules for task [9674982318019654023](https://jules.google.com/task/9674982318019654023) started by @404Setup*