### PR TITLE
Fix path traversal in jmh.py

### DIFF
--- a/jmh.py
+++ b/jmh.py
@@ -2,6 +2,7 @@
 import json
 import sys
 import os
+import re
 from collections import defaultdict
 
 def main():
@@ -33,6 +34,8 @@ def main():
             continue
 
         benchmark_name = benchmark.split('.')[-1]
+        benchmark_name = os.path.basename(benchmark_name)
+        benchmark_name = re.sub(r'[^a-zA-Z0-9_-]', '', benchmark_name)
 
         score = item.get('primaryMetric', {}).get('score')
         if score is None:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** The script `jmh.py` blindly trusted the `benchmark` name field extracted from JSON data, splitting by `.` and using the rightmost string directly as part of an output file path (`f"{benchmark_name}.txt"`). 

🎯 **Impact:** If a malicious or improperly formatted JSON file was passed (e.g. `{"benchmark": "org.example.../../../etc/passwd"}`), the script could overwrite arbitrary files or perform directory traversal.

🔧 **Fix:** Added `import re` and applied sanitization to `benchmark_name` by mapping it strictly to its basename and stripping any characters that aren't letters, numbers, hyphens, or underscores.

✅ **Verification:** A test payload executed before the patch revealed successful arbitrary write attempts. Executing the same test payload after the patch resulted in safe generation within the local context without triggering permission issues or traversing paths.

---
*PR created automatically by Jules for task [8996040764858117440](https://jules.google.com/task/8996040764858117440) started by @404Setup*